### PR TITLE
Fixes System.NullReferenceException when bindings queue gets messed up

### DIFF
--- a/src/Controls/src/Core/BindableObject.cs
+++ b/src/Controls/src/Core/BindableObject.cs
@@ -574,7 +574,8 @@ namespace Microsoft.Maui.Controls
 					while (delayQueue.Count > 0)
 					{
 						SetValueArgs s = delayQueue.Dequeue();
-						SetValueActual(s.Property, s.Context, s.Value, s.CurrentlyApplying, s.Attributes, s.Specificity, silent);
+	  					if (s!=null)
+							SetValueActual(s.Property, s.Context, s.Value, s.CurrentlyApplying, s.Attributes, s.Specificity, silent);
 					}
 
 					context.DelayedSetters = null;


### PR DESCRIPTION
### Description of Change

Added a check for null.

### Issues Fixed

What I am meeting often in a multi-threaded situation:

```
System.NullReferenceException: Object reference not set to an instance of an object.

03-29 10:10:25.660 I/DOTNET  ( 4189): System.NullReferenceException: Object reference not set to an instance of an object.
03-29 10:10:25.661 I/DOTNET  ( 4189):    at Microsoft.Maui.Controls.BindableObject.SetValueCore(BindableProperty property, Object value, SetValueFlags attributes, SetValuePrivateFlags privateAttributes, SetterSpecificity specificity) in D:\a\_work\1\s\src\Controls\src\Core\BindableObject.cs:line 577
03-29 10:10:25.661 I/DOTNET  ( 4189):    at Microsoft.Maui.Controls.BindableObject.SetValue(BindableProperty property, Object value) in D:\a\_work\1\s\src\Controls\src\Core\BindableObject.cs:line 474
```

This leads to bindings to stop working forever for this specific BindableObject.

Proposing that the backend should never crash whatever the client is doing.